### PR TITLE
Optimize event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -122,6 +134,28 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "paw"
@@ -215,6 +249,7 @@ dependencies = [
 name = "ravenwm"
 version = "0.1.0"
 dependencies = [
+ "nix",
  "ravenwm_core",
  "xcb",
 ]

--- a/src/ravenwm/Cargo.toml
+++ b/src/ravenwm/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nix = "0.23"
 ravenwm_core = { path = "../ravenwm_core" }
 xcb = "0.10"

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -67,9 +67,6 @@ fn main() {
     let ipc_fd = ipc_server.as_raw_fd();
     let xcb_fd = conn.as_raw_fd();
 
-    let ipc_fd = dbg!(ipc_fd);
-    let xcb_fd = dbg!(xcb_fd);
-
     let mut descriptors = FdSet::new();
 
     'ravenwm: loop {
@@ -82,8 +79,8 @@ fn main() {
         let ready_fds = select(None, Some(&mut descriptors), None, None, None)
             .expect("Failed to read file descriptors");
 
-        if dbg!(ready_fds) > 0 {
-            if dbg!(descriptors.contains(ipc_fd)) {
+        if ready_fds > 0 {
+            if descriptors.contains(ipc_fd) {
                 if let Some(message) = ipc_server.accept() {
                     println!("Message: {:?}", message);
 
@@ -204,7 +201,7 @@ fn main() {
                 }
             }
 
-            if dbg!(descriptors.contains(xcb_fd)) {
+            if descriptors.contains(xcb_fd) {
                 while let Some(event) = conn.poll_for_event() {
                     let response_type = event.response_type();
 

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -1,6 +1,9 @@
 mod geometry;
 mod plumage;
 
+use std::os::unix::prelude::AsRawFd;
+
+use nix::sys::select::{select, FdSet};
 use ravenwm_core::ipc;
 use xcb;
 
@@ -16,7 +19,7 @@ fn main() {
     let socket = ipc::SocketPath::new();
     let ipc_server = ipc::Server::bind(&socket);
 
-    let (conn, preferred_screen) = xcb::Connection::connect(Some(":1")).unwrap();
+    let (conn, preferred_screen) = xcb::Connection::connect(None).unwrap();
     let setup = conn.get_setup();
     let screen = setup.roots().nth(preferred_screen as usize).unwrap();
 
@@ -61,275 +64,340 @@ fn main() {
         )
     };
 
+    let ipc_fd = ipc_server.as_raw_fd();
+    let xcb_fd = conn.as_raw_fd();
+
+    let ipc_fd = dbg!(ipc_fd);
+    let xcb_fd = dbg!(xcb_fd);
+
+    let mut descriptors = FdSet::new();
+
     'ravenwm: loop {
         conn.flush();
 
-        if let Some(message) = ipc_server.accept() {
-            println!("Message: {:?}", message);
+        descriptors.clear();
+        descriptors.insert(ipc_fd);
+        descriptors.insert(xcb_fd);
 
-            match message {
-                ipc::Message::Quit => {
-                    println!("Quit");
-                    break 'ravenwm;
-                }
-                ipc::Message::CloseWindow => {
-                    if let Some(currently_focused_client) = focused_client {
-                        let is_icccm = false;
-                        if is_icccm {
-                            let wm_protocols = dbg!(wm_protocols);
-                            let wm_delete_window = dbg!(wm_delete_window);
+        let ready_fds = select(
+            descriptors.highest(),
+            Some(&mut descriptors),
+            None,
+            None,
+            None,
+        )
+        .expect("Failed to read file descriptors");
 
-                            let event = xcb::ClientMessageEvent::new(
-                                32,
-                                currently_focused_client,
-                                wm_protocols,
-                                xcb::ClientMessageData::from_data32([
-                                    wm_delete_window,
-                                    xcb::CURRENT_TIME,
-                                    0,
-                                    0,
-                                    0,
-                                ]),
-                            );
+        if dbg!(ready_fds) > 0 {
+            if dbg!(descriptors.contains(ipc_fd)) {
+                if let Some(message) = ipc_server.accept() {
+                    println!("Message: {:?}", message);
 
-                            println!("Sending WM_DELETE_WINDOW event");
-                            xcb::send_event(
-                                &conn,
-                                false,
-                                currently_focused_client,
-                                xcb::EVENT_MASK_NO_EVENT,
-                                &event,
-                            );
-                        } else {
-                            println!("Killing client: {}", currently_focused_client);
-                            xcb::kill_client(&conn, currently_focused_client);
+                    match message {
+                        ipc::Message::Quit => {
+                            println!("Quit");
+                            break 'ravenwm;
                         }
+                        ipc::Message::CloseWindow => {
+                            if let Some(currently_focused_client) = focused_client {
+                                let is_icccm = false;
+                                if is_icccm {
+                                    let wm_protocols = dbg!(wm_protocols);
+                                    let wm_delete_window = dbg!(wm_delete_window);
 
-                        if let Some(currently_focused_index) = clients
-                            .iter()
-                            .position(|client| client.id() == currently_focused_client)
-                        {
-                            clients.remove(currently_focused_index);
+                                    let event = xcb::ClientMessageEvent::new(
+                                        32,
+                                        currently_focused_client,
+                                        wm_protocols,
+                                        xcb::ClientMessageData::from_data32([
+                                            wm_delete_window,
+                                            xcb::CURRENT_TIME,
+                                            0,
+                                            0,
+                                            0,
+                                        ]),
+                                    );
+
+                                    println!("Sending WM_DELETE_WINDOW event");
+                                    xcb::send_event(
+                                        &conn,
+                                        false,
+                                        currently_focused_client,
+                                        xcb::EVENT_MASK_NO_EVENT,
+                                        &event,
+                                    );
+                                } else {
+                                    println!("Killing client: {}", currently_focused_client);
+                                    xcb::kill_client(&conn, currently_focused_client);
+                                }
+
+                                if let Some(currently_focused_index) = clients
+                                    .iter()
+                                    .position(|client| client.id() == currently_focused_client)
+                                {
+                                    clients.remove(currently_focused_index);
+                                }
+
+                                focused_client = clients.last().map(|client| client.id());
+                            }
                         }
+                        ipc::Message::MoveWindow { x, y } => {
+                            if let Some(focused_window) = focused_client {
+                                xcb::configure_window(
+                                    &conn,
+                                    focused_window,
+                                    &[
+                                        (xcb::CONFIG_WINDOW_X as u16, x),
+                                        (xcb::CONFIG_WINDOW_Y as u16, y),
+                                    ],
+                                );
+                            }
+                        }
+                        ipc::Message::SetBorderWidth { width } => {
+                            window_border_width = width;
 
-                        focused_client = clients.last().map(|client| client.id());
-                    }
-                }
-                ipc::Message::MoveWindow { x, y } => {
-                    if let Some(focused_window) = focused_client {
-                        xcb::configure_window(
-                            &conn,
-                            focused_window,
-                            &[
-                                (xcb::CONFIG_WINDOW_X as u16, x),
-                                (xcb::CONFIG_WINDOW_Y as u16, y),
-                            ],
-                        );
-                    }
-                }
-                ipc::Message::SetBorderWidth { width } => {
-                    window_border_width = width;
+                            for client in &clients {
+                                let window_geometry =
+                                    xcb::get_geometry(&conn, client.id()).get_reply().unwrap();
 
-                    for client in &clients {
-                        let window_geometry =
-                            xcb::get_geometry(&conn, client.id()).get_reply().unwrap();
+                                let current_border_width = window_geometry.border_width();
 
-                        let current_border_width = window_geometry.border_width();
+                                let border_width_delta =
+                                    window_border_width as i32 - current_border_width as i32;
 
-                        let border_width_delta =
-                            window_border_width as i32 - current_border_width as i32;
+                                let mut window_dimensions = Rectangle::new(
+                                    window_geometry.x(),
+                                    window_geometry.y(),
+                                    window_geometry.width(),
+                                    window_geometry.height(),
+                                );
 
-                        let mut window_dimensions = Rectangle::new(
-                            window_geometry.x(),
-                            window_geometry.y(),
-                            window_geometry.width(),
-                            window_geometry.height(),
-                        );
+                                window_dimensions.width -= 2 * border_width_delta as u16;
+                                window_dimensions.height -= 2 * border_width_delta as u16;
 
-                        window_dimensions.width -= 2 * border_width_delta as u16;
-                        window_dimensions.height -= 2 * border_width_delta as u16;
+                                xcb::configure_window(
+                                    &conn,
+                                    client.id(),
+                                    &[
+                                        (
+                                            xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                            window_border_width,
+                                        ),
+                                        (
+                                            xcb::CONFIG_WINDOW_WIDTH as u16,
+                                            window_dimensions.width as u32,
+                                        ),
+                                        (
+                                            xcb::CONFIG_WINDOW_HEIGHT as u16,
+                                            window_dimensions.height as u32,
+                                        ),
+                                    ],
+                                );
+                            }
+                        }
+                        ipc::Message::SetBorderColor { color } => {
+                            window_border_color = Color::rgb(color.r, color.g, color.b);
 
-                        xcb::configure_window(
-                            &conn,
-                            client.id(),
-                            &[
-                                (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16, window_border_width),
-                                (
-                                    xcb::CONFIG_WINDOW_WIDTH as u16,
-                                    window_dimensions.width as u32,
-                                ),
-                                (
-                                    xcb::CONFIG_WINDOW_HEIGHT as u16,
-                                    window_dimensions.height as u32,
-                                ),
-                            ],
-                        );
-                    }
-                }
-                ipc::Message::SetBorderColor { color } => {
-                    window_border_color = Color::rgb(color.r, color.g, color.b);
-
-                    for client in &clients {
-                        xcb::change_window_attributes(
-                            &conn,
-                            client.id(),
-                            &[(xcb::CW_BORDER_PIXEL, window_border_color.into())],
-                        );
+                            for client in &clients {
+                                xcb::change_window_attributes(
+                                    &conn,
+                                    client.id(),
+                                    &[(xcb::CW_BORDER_PIXEL, window_border_color.into())],
+                                );
+                            }
+                        }
                     }
                 }
             }
-        }
 
-        while let Some(event) = conn.poll_for_event() {
-            let response_type = event.response_type();
+            if dbg!(descriptors.contains(xcb_fd)) {
+                while let Some(event) = conn.poll_for_event() {
+                    let response_type = event.response_type();
 
-            println!("Received event {}", response_type);
+                    println!("Received event {}", response_type);
 
-            match response_type {
-                xcb::MAP_REQUEST => {
-                    println!("XCB_MAP_REQUEST");
+                    match response_type {
+                        xcb::MAP_REQUEST => {
+                            println!("XCB_MAP_REQUEST");
 
-                    let map_request: &xcb::MapRequestEvent = unsafe { xcb::cast_event(&event) };
+                            let map_request: &xcb::MapRequestEvent =
+                                unsafe { xcb::cast_event(&event) };
 
-                    let client = XClient {
-                        id: map_request.window(),
-                    };
+                            let client = XClient {
+                                id: map_request.window(),
+                            };
 
-                    let window_gap_width = 16u32;
+                            let window_gap_width = 16u32;
 
-                    let mut window_dimensions =
-                        Rectangle::new(0, 0, screen.width_in_pixels(), screen.height_in_pixels());
+                            let mut window_dimensions = Rectangle::new(
+                                0,
+                                0,
+                                screen.width_in_pixels(),
+                                screen.height_in_pixels(),
+                            );
 
-                    window_dimensions.deflate(window_gap_width as i16, window_gap_width as i16);
+                            window_dimensions
+                                .deflate(window_gap_width as i16, window_gap_width as i16);
 
-                    window_dimensions.width -= 2 * window_border_width as u16;
-                    window_dimensions.height -= 2 * window_border_width as u16;
+                            window_dimensions.width -= 2 * window_border_width as u16;
+                            window_dimensions.height -= 2 * window_border_width as u16;
 
-                    match layout_mode {
-                        LayoutMode::Tiling => {
-                            xcb::configure_window(
+                            match layout_mode {
+                                LayoutMode::Tiling => {
+                                    xcb::configure_window(
+                                        &conn,
+                                        client.id(),
+                                        &[
+                                            (
+                                                xcb::CONFIG_WINDOW_X as u16,
+                                                window_dimensions.x as u32,
+                                            ),
+                                            (
+                                                xcb::CONFIG_WINDOW_Y as u16,
+                                                window_dimensions.y as u32,
+                                            ),
+                                            (
+                                                xcb::CONFIG_WINDOW_WIDTH as u16,
+                                                window_dimensions.width as u32,
+                                            ),
+                                            (
+                                                xcb::CONFIG_WINDOW_HEIGHT as u16,
+                                                window_dimensions.height as u32,
+                                            ),
+                                            (
+                                                xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                                window_border_width,
+                                            ),
+                                        ],
+                                    );
+                                }
+                                LayoutMode::Stacking => {}
+                            }
+
+                            xcb::change_window_attributes(
                                 &conn,
                                 client.id(),
-                                &[
-                                    (xcb::CONFIG_WINDOW_X as u16, window_dimensions.x as u32),
-                                    (xcb::CONFIG_WINDOW_Y as u16, window_dimensions.y as u32),
-                                    (
-                                        xcb::CONFIG_WINDOW_WIDTH as u16,
-                                        window_dimensions.width as u32,
-                                    ),
-                                    (
-                                        xcb::CONFIG_WINDOW_HEIGHT as u16,
-                                        window_dimensions.height as u32,
-                                    ),
-                                    (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16, window_border_width),
-                                ],
+                                &[(xcb::CW_BORDER_PIXEL, window_border_color.into())],
+                            );
+
+                            xcb::map_window(&conn, client.id());
+
+                            focused_client = Some(client.id());
+
+                            clients.push(client);
+                        }
+                        xcb::CONFIGURE_REQUEST => {
+                            println!("XCB_CONFIGURE_REQUEST");
+
+                            let configure_request: &xcb::ConfigureRequestEvent =
+                                unsafe { xcb::cast_event(&event) };
+
+                            let mut values = Vec::with_capacity(7);
+
+                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_X as u16) == 0 {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_X as u16,
+                                    configure_request.x() as u32,
+                                ));
+                            }
+
+                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_Y as u16) == 0 {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_Y as u16,
+                                    configure_request.y() as u32,
+                                ));
+                            }
+
+                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_WIDTH as u16)
+                                == 0
+                            {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_WIDTH as u16,
+                                    configure_request.width() as u32,
+                                ));
+                            }
+
+                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_HEIGHT as u16)
+                                == 0
+                            {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_HEIGHT as u16,
+                                    configure_request.height() as u32,
+                                ));
+                            }
+
+                            if configure_request.value_mask()
+                                & (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16)
+                                == 0
+                            {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                    configure_request.border_width() as u32,
+                                ));
+                            }
+
+                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_SIBLING as u16)
+                                == 0
+                            {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_SIBLING as u16,
+                                    configure_request.sibling(),
+                                ));
+                            }
+
+                            if configure_request.value_mask()
+                                & (xcb::CONFIG_WINDOW_STACK_MODE as u16)
+                                == 0
+                            {
+                                values.push((
+                                    xcb::CONFIG_WINDOW_STACK_MODE as u16,
+                                    configure_request.stack_mode() as u32,
+                                ));
+                            }
+
+                            let values = dbg!(values);
+
+                            xcb::configure_window(
+                                &conn,
+                                configure_request.window(),
+                                values.as_slice(),
+                            );
+
+                            xcb::change_window_attributes(
+                                &conn,
+                                configure_request.window(),
+                                &[(
+                                    xcb::CW_EVENT_MASK,
+                                    xcb::EVENT_MASK_PROPERTY_CHANGE | xcb::EVENT_MASK_FOCUS_CHANGE,
+                                )],
                             );
                         }
-                        LayoutMode::Stacking => {}
-                    }
+                        xcb::MOTION_NOTIFY => {
+                            println!("XCB_MOTION_NOTIFY");
 
-                    xcb::change_window_attributes(
-                        &conn,
-                        client.id(),
-                        &[(xcb::CW_BORDER_PIXEL, window_border_color.into())],
-                    );
-
-                    xcb::map_window(&conn, client.id());
-
-                    focused_client = Some(client.id());
-
-                    clients.push(client);
-                }
-                xcb::CONFIGURE_REQUEST => {
-                    println!("XCB_CONFIGURE_REQUEST");
-
-                    let configure_request: &xcb::ConfigureRequestEvent =
-                        unsafe { xcb::cast_event(&event) };
-
-                    let mut values = Vec::with_capacity(7);
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_X as u16) == 0 {
-                        values.push((xcb::CONFIG_WINDOW_X as u16, configure_request.x() as u32));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_Y as u16) == 0 {
-                        values.push((xcb::CONFIG_WINDOW_Y as u16, configure_request.y() as u32));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_WIDTH as u16) == 0 {
-                        values.push((
-                            xcb::CONFIG_WINDOW_WIDTH as u16,
-                            configure_request.width() as u32,
-                        ));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_HEIGHT as u16) == 0 {
-                        values.push((
-                            xcb::CONFIG_WINDOW_HEIGHT as u16,
-                            configure_request.height() as u32,
-                        ));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16)
-                        == 0
-                    {
-                        values.push((
-                            xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
-                            configure_request.border_width() as u32,
-                        ));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_SIBLING as u16) == 0 {
-                        values.push((
-                            xcb::CONFIG_WINDOW_SIBLING as u16,
-                            configure_request.sibling(),
-                        ));
-                    }
-
-                    if configure_request.value_mask() & (xcb::CONFIG_WINDOW_STACK_MODE as u16) == 0
-                    {
-                        values.push((
-                            xcb::CONFIG_WINDOW_STACK_MODE as u16,
-                            configure_request.stack_mode() as u32,
-                        ));
-                    }
-
-                    let values = dbg!(values);
-
-                    xcb::configure_window(&conn, configure_request.window(), values.as_slice());
-
-                    xcb::change_window_attributes(
-                        &conn,
-                        configure_request.window(),
-                        &[(
-                            xcb::CW_EVENT_MASK,
-                            xcb::EVENT_MASK_PROPERTY_CHANGE | xcb::EVENT_MASK_FOCUS_CHANGE,
-                        )],
-                    );
-                }
-                xcb::MOTION_NOTIFY => {
-                    println!("XCB_MOTION_NOTIFY");
-
-                    let _motion_notify: &xcb::MotionNotifyEvent =
-                        unsafe { xcb::cast_event(&event) };
-                }
-                xcb::BUTTON_PRESS => {
-                    let button_press: &xcb::ButtonPressEvent = unsafe { xcb::cast_event(&event) };
-
-                    println!("Mouse button '{}' pressed", button_press.detail());
-
-                    if button_press.detail() == 0x1 {
-                        let child_window = button_press.child();
-
-                        println!("Child window: {}", child_window);
-
-                        if child_window != xcb::NONE {
-                            println!("Focusing window: {}", child_window);
-                            focused_client = Some(child_window);
+                            let _motion_notify: &xcb::MotionNotifyEvent =
+                                unsafe { xcb::cast_event(&event) };
                         }
+                        xcb::BUTTON_PRESS => {
+                            let button_press: &xcb::ButtonPressEvent =
+                                unsafe { xcb::cast_event(&event) };
+
+                            println!("Mouse button '{}' pressed", button_press.detail());
+
+                            if button_press.detail() == 0x1 {
+                                let child_window = button_press.child();
+
+                                println!("Child window: {}", child_window);
+
+                                if child_window != xcb::NONE {
+                                    println!("Focusing window: {}", child_window);
+                                    focused_client = Some(child_window);
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                _ => {}
             }
         }
     }

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -79,14 +79,8 @@ fn main() {
         descriptors.insert(ipc_fd);
         descriptors.insert(xcb_fd);
 
-        let ready_fds = select(
-            descriptors.highest(),
-            Some(&mut descriptors),
-            None,
-            None,
-            None,
-        )
-        .expect("Failed to read file descriptors");
+        let ready_fds = select(None, Some(&mut descriptors), None, None, None)
+            .expect("Failed to read file descriptors");
 
         if dbg!(ready_fds) > 0 {
             if dbg!(descriptors.contains(ipc_fd)) {

--- a/src/ravenwm_core/src/ipc.rs
+++ b/src/ravenwm_core/src/ipc.rs
@@ -3,6 +3,7 @@ mod message;
 use std::fs;
 use std::io::{self, ErrorKind, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::path::PathBuf;
 
 pub use message::*;
@@ -74,8 +75,6 @@ impl Server {
         let listener = UnixListener::bind(&socket_path.0)
             .expect(&format!("Failed to connect to {}", socket_path.0));
 
-        listener.set_nonblocking(true).unwrap();
-
         Self { listener }
     }
 
@@ -93,13 +92,15 @@ impl Server {
                 Some(message)
             }
             Err(err) => {
-                if err.kind() == ErrorKind::WouldBlock {
-                    return None;
-                }
-
                 println!("Socket error: {}", err);
                 None
             }
         }
+    }
+}
+
+impl AsRawFd for Server {
+    fn as_raw_fd(&self) -> RawFd {
+        self.listener.as_raw_fd()
     }
 }


### PR DESCRIPTION
I noticed that `ravenwm` was taking up ~100% CPU usage at idle.

This is obviously not great, so this PR optimizes the event loop to _not_ do that.

We achieve this by making use of [`select(2)`](https://man7.org/linux/man-pages/man2/select.2.html) to only advance the event loop when we have events to process, either from the X server or from our IPC socket.