### PR TITLE
Upgrade to `xcb` 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,15 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,11 +396,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xcb"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771e2b996df720cd1c6dd9ff90f62d91698fd3610cc078388d0564bdd6622a9c"
+checksum = "0c07d611a672657a3385b126805e87e91011a859b7e97ec417adf57228799c54"
 dependencies = [
+ "bitflags",
  "libc",
- "log",
  "quick-xml",
 ]

--- a/src/ravenwm/Cargo.toml
+++ b/src/ravenwm/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 nix = "0.23"
 ravenwm_core = { path = "../ravenwm_core" }
-xcb = "0.10"
+xcb = "1.0"

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -40,9 +40,7 @@ fn main() -> xcb::Result<()> {
         height: 1,
         border_width: 0,
         class: x::WindowClass::InputOnly,
-        // TODO: Verify that the value for `visual` is correct.
-        // This used to be `xcb::NONE`.
-        visual: 0,
+        visual: x::Window::none().resource_id(),
         value_list: &[],
     });
 

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -265,64 +265,59 @@ fn main() -> xcb::Result<()> {
 
                             let mut values = Vec::with_capacity(7);
 
-                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_X as u16) == 0 {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_X as u16,
-                                    configure_request.x() as u32,
-                                ));
-                            }
-
-                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_Y as u16) == 0 {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_Y as u16,
-                                    configure_request.y() as u32,
-                                ));
-                            }
-
-                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_WIDTH as u16)
-                                == 0
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::X)
                             {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_WIDTH as u16,
-                                    configure_request.width() as u32,
+                                values.push(x::ConfigWindow::X(configure_request.x() as i32));
+                            }
+
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::Y)
+                            {
+                                values.push(x::ConfigWindow::Y(configure_request.y() as i32));
+                            }
+
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::WIDTH)
+                            {
+                                values
+                                    .push(x::ConfigWindow::Width(configure_request.width() as u32));
+                            }
+
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::HEIGHT)
+                            {
+                                values.push(x::ConfigWindow::Height(
+                                    configure_request.height() as u32
                                 ));
                             }
 
-                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_HEIGHT as u16)
-                                == 0
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::BORDER_WIDTH)
                             {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_HEIGHT as u16,
-                                    configure_request.height() as u32,
-                                ));
-                            }
-
-                            if configure_request.value_mask()
-                                & (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16)
-                                == 0
-                            {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                values.push(x::ConfigWindow::BorderWidth(
                                     configure_request.border_width() as u32,
                                 ));
                             }
 
-                            if configure_request.value_mask() & (xcb::CONFIG_WINDOW_SIBLING as u16)
-                                == 0
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::SIBLING)
                             {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_SIBLING as u16,
-                                    configure_request.sibling(),
-                                ));
+                                values.push(x::ConfigWindow::Sibling(configure_request.sibling()));
                             }
 
-                            if configure_request.value_mask()
-                                & (xcb::CONFIG_WINDOW_STACK_MODE as u16)
-                                == 0
+                            if configure_request
+                                .value_mask()
+                                .contains(x::ConfigWindowMask::STACK_MODE)
                             {
-                                values.push((
-                                    xcb::CONFIG_WINDOW_STACK_MODE as u16,
-                                    configure_request.stack_mode() as u32,
+                                values.push(x::ConfigWindow::StackMode(
+                                    configure_request.stack_mode(),
                                 ));
                             }
 

--- a/src/ravenwm/src/main.rs
+++ b/src/ravenwm/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> xcb::Result<()> {
     let mut descriptors = FdSet::new();
 
     'ravenwm: loop {
-        conn.flush();
+        conn.flush()?;
 
         descriptors.clear();
         descriptors.insert(ipc_fd);
@@ -99,9 +99,6 @@ fn main() -> xcb::Result<()> {
                             if let Some(currently_focused_client) = focused_client {
                                 let is_icccm = false;
                                 if is_icccm {
-                                    let wm_protocols = dbg!(wm_protocols);
-                                    let wm_delete_window = dbg!(wm_delete_window);
-
                                     let event = x::ClientMessageEvent::new(
                                         currently_focused_client,
                                         wm_protocols.atom(),
@@ -367,7 +364,7 @@ fn main() -> xcb::Result<()> {
         window: meta_window,
     });
 
-    conn.flush();
+    conn.flush()?;
 
     Ok(())
 }


### PR DESCRIPTION
v1 of [`xcb`](https://github.com/rust-x-bindings/rust-xcb) is now available with a brand new API, so we should upgrade to it before continuing much further with development.

The migration was relatively straightforward and the new API is _so_ much nicer!